### PR TITLE
Fix/receive deadlock

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,4 +5,14 @@ cd core
 cargo build --release
 
 cd ..
-mv $SCRIPT_DIR/core/target/release/libcore.dylib $SCRIPT_DIR/repo_sync/core.so
+
+if [ "$(uname)" == 'Darwin' ]; then
+    # MacOS
+    mv $SCRIPT_DIR/core/target/release/libcore.dylib $SCRIPT_DIR/repo_sync/core.so
+elif [ "$(expr substr $(uname -s) 1 5)" == 'Linux' ]; then
+    # Linux
+    mv $SCRIPT_DIR/core/target/release/libcore.so $SCRIPT_DIR/repo_sync/core.so
+else
+  echo "Your platform ($(uname -a)) is not supported."
+  exit 1
+fi

--- a/core/src/fileopration.rs
+++ b/core/src/fileopration.rs
@@ -54,10 +54,13 @@ impl<'a> FileOperation<'a> {
 
             if diff(&cache_hash, &current_hash)? {
                 // write cache file to target file
+                // external update.
                 let text = read(&cache_file_path)?;
                 write(&self.path, &text)?;
+                write(&cache_file, &cache_hash.into_bytes())?;
                 save_history(&cache_file_path, &self.cache_dir, true)?;
             } else if diff(&current_hash, &_hash)? {
+                // internal cache update.
                 copy_file(&self.path, &cache_file_path)?;
                 write(&cache_file, &_hash.into_bytes())?;
                 save_history(&self.path, &self.cache_dir, false)?;


### PR DESCRIPTION
- 2つのクライアントで送受信をしたときに、1→2に送信した場合、2のハッシュが永遠に生成されてしまう問題の修正。
- build.shを改善（Linuxでのビルドに対応）

